### PR TITLE
Fix static images for build

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -36,24 +36,6 @@ svg {
   font-style: normal;
 }
 
-.amaranth-bold {
-  font-family: "Amaranth", sans-serif;
-  font-weight: 700;
-  font-style: normal;
-}
-
-.amaranth-regular-italic {
-  font-family: "Amaranth", sans-serif;
-  font-weight: 400;
-  font-style: italic;
-}
-
-.amaranth-bold-italic {
-  font-family: "Amaranth", sans-serif;
-  font-weight: 700;
-  font-style: italic;
-}
-
 .tauri-regular {
   font-family: "Tauri", sans-serif;
   font-weight: 400;
@@ -67,10 +49,7 @@ svg {
 }
 
 /** Background Images **/
-.img_9804 {
-  background-image: url('src/assets/IMG_9804.webp');
-  /*background-position: center;*/
-  /*background-size: cover;*/
+.bg-center {
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
@@ -82,14 +61,6 @@ svg {
   background-repeat: repeat;
   background-color: rgba(0,0,0,.75);
   background-blend-mode: multiply;
-}
-
-.bg-9648 {
-  background-image: url("/src/assets/IMG_9648.webp");
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  position: relative;
 }
 
 .paragraph {

--- a/src/components/CarouselBanner.vue
+++ b/src/components/CarouselBanner.vue
@@ -11,7 +11,7 @@ defineProps<{
 
 <template>
   <!-- grid -->
-<section class="grid text-white img_9804 text-center align-middle h-1/2 space-y-4 place-items-center border-olive border-b-8" style="height: 22.813vw; min-height: 20vw" id="carousel">
+<section class="grid text-white bg-center text-center align-middle h-1/2 space-y-4 place-items-center border-olive border-b-8" style="height: 22.813vw; min-height: 20vw" id="carousel">
   <!-- 9804 -->
   <p class="text-4xl sm:text-4xl md:text-7xl tauri-regular" style="-webkit-text-stroke: 3px black;">{{banner_text}}</p>
   <button class="bg-black border-5 rounded-full sm:text-2xl md:text-3xl p-2 sm:p-5 border-4 border-olive mb-8"><RouterLink :to="{name: route_name}">{{ button_text }}</RouterLink></button>

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -6,7 +6,7 @@ import ContactForm from "@/components/ContactForm.vue";
 <template>
   <Hero h1="Contact Us" subtitle="Get in touch today"></Hero>
   <!-- Can't use TextBlock component here due to multi-paragraphs -->
-  <article class="text-white py-36 paragraph" :style="{ backgroundImage: 'url(/src/assets/016A3298.webp)' }">
+  <article class="text-white py-36 paragraph" :style="{ 'background-image': `url(${_016A3298})` }">
     <p class="px-20 py-10 tauri-regular text-xl">
       If you need any more information on the range of services Dubai-Landscapes offers,
       or want to hire our team to carry out work on your property in the UAE, we’re always here to help.
@@ -23,3 +23,6 @@ import ContactForm from "@/components/ContactForm.vue";
   </article>
   <ContactForm></ContactForm>
 </template>
+<script lang="ts">
+  import _016A3298 from '@/assets/016A3298.webp';
+</script>

--- a/src/views/FAQView.vue
+++ b/src/views/FAQView.vue
@@ -17,7 +17,7 @@ item4 = ref(false);
 <template>
   <Hero h1="Frequently Asked Questions" subtitle=""></Hero>
   <!-- Can't use TextBlock component here due to multi-paragraphs -->
-  <article class="text-white py-36 paragraph" :style="{ backgroundImage: 'url(/src/assets/016A3298.webp)' }">
+  <article class="text-white py-36 paragraph" :style="{ 'background-image': `url(${_016A3298})` }">
     <p class="px-20 py-10 tauri-regular text-xl">
       Want to know more about the services we offer?
       Maybe you have specific questions about our processes that you’d like to learn more about?
@@ -73,3 +73,6 @@ item4 = ref(false);
     </article>
   </section>
 </template>
+<script lang="ts">
+  import _016A3298 from '@/assets/016A3298.webp';
+</script>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,26 +6,29 @@ import { ref } from 'vue';
 let banner_text = ref("UAE's leading landscapes");
 let button_text = ref("View our Gallery!")
 let route_name = ref("gallery")
+let background_image = ref(IMG_9528)
+
+//Import static assets
+import IMG_9528 from '@/assets/IMG_9528.webp';
+import IMG_9665 from '@/assets/IMG_9665.webp';
+import IMG_9648 from '@/assets/IMG_9648.webp';
+import IMG_9804 from '@/assets/IMG_9804.webp';
 
 const carousel_options = [
     // ["banner text", "button text", "route path", "background image"]
-    ['Got Questions?','Contact Us!','contact-us', 'IMG_9665.webp'],
-    ['Our Services','View our services','services', 'IMG_9648.webp'],
-    ["UAE's leading landscapes", 'View our Gallery!', 'gallery', 'IMG_9804.webp']
+    ['Got Questions?','Contact Us!','contact-us', IMG_9665],
+    ['Our Services','View our services','services', IMG_9648],
+    ["UAE's leading landscapes", 'View our Gallery!', 'gallery', IMG_9804]
 ]
 
 let i = 0;
 //Update carousel every 5 seconds
 window.setInterval(function(){
   if(i < carousel_options.length) {
-    banner_text.value = carousel_options[i][0]
-    button_text.value = carousel_options[i][1]
-    route_name.value = carousel_options[i][2]
-    let carousel = document.getElementById('carousel');
-    if(carousel) {
-      carousel!.style.backgroundImage = "url('/src/assets/" + carousel_options[i][3] + "')";
-    }
-
+    banner_text.value = carousel_options[i][0] //Take the first value from the array
+    button_text.value = carousel_options[i][1] //Take the second value from the array
+    route_name.value = carousel_options[i][2] //Take the third value from the array
+    background_image.value = carousel_options[i][3] //Take the import from the array, which links to the static assets above.
     i++;
   } else {
     i = 0; //Reset counter to go through the carousel again
@@ -34,7 +37,7 @@ window.setInterval(function(){
 </script>
 
 <template>
-  <Carousel :banner_text="banner_text" :button_text="button_text" :route_name="route_name" id="carousel"></Carousel>
+  <Carousel :banner_text="banner_text" :button_text="button_text" :route_name="route_name" id="carousel" :style="{ 'background-image': `url(${background_image})` }">></Carousel>
   <section class="bg-grass text-white">
     <h1 class="text-7xl text-center pt-5 font-bold tauri-regular">Garden Landscaping</h1>
     <p class="px-20 py-10 tauri-regular">

--- a/src/views/ServicesView.vue
+++ b/src/views/ServicesView.vue
@@ -6,7 +6,7 @@ import GreenBanner from "@/components/GreenBanner.vue";
 
 <template>
   <Hero h1="Landscaping Services" subtitle="For your personal oasis in the UAE"></Hero>
-  <TextBlock background_img="IMG_9413.webp">
+  <TextBlock :style="{ 'background-image': `url(${IMG_9413})` }">
     Dubai-Landscapes is one of the most experienced and reliable garden landscaping companies in the UAE.
     Experts in both soft and hard landscaping, we’re able to do it all, from providing perfect paving to enhancing
     gardens with flowers and plants that are able to withstand the UAE’s unique climate. Our team is full of local
@@ -14,39 +14,50 @@ import GreenBanner from "@/components/GreenBanner.vue";
   </TextBlock>
   <GreenBanner>Our range of landscaping services includes:</GreenBanner>
   <section class="grid grid-cols-3 text-center text-3xl md:text-6xl tauri-regular text-white grid-height text-outline" id="services-grid">
-    <div class="relative grid-height" style="background-image: url('/src/assets/IMG_9772.webp');">
+    <div class="relative grid-height" :style="{ 'background-image': `url(${IMG_9772})` }">
       <div class="absolute inset-0 flex items-center justify-center">Gazebos</div>
     </div>
-    <div class="relative grid-height" style="background-image: url('/src/assets/IMG_9413.webp');">
+    <div class="relative grid-height" :style="{ 'background-image': `url(${IMG_9413})` }">
       <div class="absolute inset-0 flex items-center justify-center">Paving</div>
     </div>
-    <div class="relative grid-height" style="background-image: url('/src/assets/IMG_9648.webp');">
+    <div class="relative grid-height" :style="{ 'background-image': `url(${IMG_9648})` }">
       <div class="absolute inset-0 flex items-center justify-center">Pergola</div>
     </div>
-    <div class="relative grid-height" style="background-image: url('/src/assets/016A3065.webp');">
+    <div class="relative grid-height" :style="{ 'background-image': `url(${_016A3065})` }">
       <div class="absolute inset-0 flex items-center justify-center">Decking</div>
     </div>
-    <div class="relative grid-height" style="background-image: url('/src/assets/016A3298.webp');">
+    <div class="relative grid-height" :style="{ 'background-image': `url(${_016A3298})` }">
       <div class="absolute inset-0 flex items-center justify-center">Water Features</div>
     </div>
-    <div class="relative grid-height" style="background-image: url('/src/assets/016A3170.webp');">
+    <div class="relative grid-height" :style="{ 'background-image': `url(${_016A3170})` }">
       <div class="absolute inset-0 flex items-center justify-center">Barbecue Areas</div>
     </div>
   </section>
 
   <GreenBanner>and much more!</GreenBanner>
-  <TextBlock background_img="IMG_9685.webp">
+  <TextBlock :style="{ 'background-image': `url(${IMG_9685})` }">
     Our team can transform every garden or outdoor space, taking on board the unique requirements of our customers.
     We never take a ‘one size fits all’ approach, instead tailoring our services specifically to the needs of our clients
   </TextBlock>
-  <TextBlock background_img="uk_flag.webp">
+  <TextBlock :style="{ 'background-image': `url(${uk_flag})` }">
     A British-owned company, whose entire team is English managed, we always use products that have been manufactured
     using the highest quality materials. This includes award-winning artificial turf from Easigrass,
     a product that is 100% British designed as well as child and pet safe.
   </TextBlock>
-  <TextBlock background_img="IMG_9596.webp">
+  <TextBlock :style="{ 'background-image': `url(${IMG_9596})` }">
     Operating across the entirety of Dubai and Abu Dhabi, whatever landscaping services you require, Dubai-Landscapes
     is here to help. Contact us by WhatsApp, on the phone or by filling out our online form,
     and a member of our team will be able to help.
   </TextBlock>
 </template>
+<script lang="ts">
+  import IMG_9772 from '@/assets/IMG_9772.webp';
+  import IMG_9413 from '@/assets/IMG_9413.webp';
+  import IMG_9648 from '@/assets/IMG_9648.webp';
+  import IMG_9685 from '@/assets/IMG_9685.webp';
+  import IMG_9596 from '@/assets/IMG_9596.webp';
+  import _016A3065 from '@/assets/016A3065.webp';
+  import _016A3298 from '@/assets/016A3298.webp';
+  import _016A3170 from '@/assets/016A3170.webp';
+  import uk_flag from '@/assets/uk_flag.webp';
+</script>


### PR DESCRIPTION
Vue/Vite seems to have a problem with Typescript in that the @ alias cannot be used within the url parameter to reference static assets. To overcome this, troubleshooting included dynamically replacing class names with JavaScript, but this was deemed inefficient. The ["node"] type was added to TS config but this has no effect within the IDE, and prevented the build from passing.

The solution was found in import statements contained in the script tags. These tags allow for the @ alias to work correctly, and the site can now be successfully deployed.



